### PR TITLE
Allow to skip validation in development context

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace StudioMitte\FriendlyCaptcha;
 
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -16,6 +17,7 @@ class Configuration
     protected string $puzzleUrl = '';
     protected string $verifyUrl = '';
     protected string $jsPath = '';
+    protected bool $skipDevValidation = false;
 
     public function __construct(Site $site = null)
     {
@@ -31,6 +33,7 @@ class Configuration
         $this->puzzleUrl = trim($siteConfiguration['friendlycaptcha_puzzle_url'] ?? '');
         $this->verifyUrl = trim($siteConfiguration['friendlycaptcha_verify_url'] ?? '');
         $this->jsPath = trim($siteConfiguration['friendlycaptcha_js_path'] ?? '');
+        $this->skipDevValidation = (bool)($siteConfiguration['friendlycaptcha_skip_dev_validation'] ?? false);
     }
 
     public function isEnabled(): bool
@@ -67,5 +70,10 @@ class Configuration
     public function getJsPath(): string
     {
         return $this->jsPath ?: self::DEFAULT_JS_PATH;
+    }
+
+    public function hasSkipDevValidation(): bool
+    {
+        return Environment::getContext()->isDevelopment() && $this->skipDevValidation;
     }
 }

--- a/Classes/Service/Api.php
+++ b/Classes/Service/Api.php
@@ -32,6 +32,10 @@ class Api
 
     public function verify(string $solution = ''): bool
     {
+        if ($this->configuration->hasSkipDevValidation()) {
+            return true;
+        }
+
         $solution = $solution ?: $this->getSolutionFromRequest();
         if (!$solution || !$this->configuration->isEnabled()) {
             return false;

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -41,6 +41,13 @@ call_user_func(
                 'default' => \StudioMitte\FriendlyCaptcha\Configuration::DEFAULT_JS_PATH,
             ],
         ];
-        $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',--div--;' . $lll . 'site.configuration.tab, friendlycaptcha_site_key,friendlycaptcha_secret_key,friendlycaptcha_puzzle_url,friendlycaptcha_verify_url,friendlycaptcha_js_path,';
+        $GLOBALS['SiteConfiguration']['site']['columns']['friendlycaptcha_skip_dev_validation'] = [
+            'label' => $lll . 'site.configuration.skip_dev_validation',
+            'description' => $lll . 'site.configuration.skip_dev_validation.description',
+            'config' => [
+                'type' => 'check',
+            ],
+        ];
+        $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',--div--;' . $lll . 'site.configuration.tab, friendlycaptcha_site_key,friendlycaptcha_secret_key,friendlycaptcha_puzzle_url,friendlycaptcha_verify_url,friendlycaptcha_js_path,friendlycaptcha_skip_dev_validation,';
     }
 );

--- a/Resources/Private/Language/Configuration.xlf
+++ b/Resources/Private/Language/Configuration.xlf
@@ -20,6 +20,12 @@
 			<trans-unit id="site.configuration.js_path">
                 <source>JavaScript Path</source>
             </trans-unit>
+            <trans-unit id="site.configuration.skip_dev_validation">
+                <source>Skip validation in Development context</source>
+            </trans-unit>
+            <trans-unit id="site.configuration.skip_dev_validation.description">
+                <source>Must never be used on your live website. Only possible in Development context. Can be useful for automated form testing.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/RequestTrait.php
+++ b/Tests/RequestTrait.php
@@ -19,6 +19,7 @@ trait RequestTrait
             'friendlycaptcha_secret_key' => $secretKey,
             'friendlycaptcha_site_key' => $siteKey,
             'friendlycaptcha_verify_url' => 'https://verify,https://verify2',
+            'friendlycaptcha_skip_dev_validation' => false,
         ]);
         $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())
             ->withAttribute('site', $site)


### PR DESCRIPTION
We have several acceptance tests in our projects which test the processing of form data after it was submitted.

For this reason we need to bypass the FriendlyCaptcha validation. To avoid missconfiguration on production systems, this feature is limited to Development contexts.

I would recommend to set the value via ENV variables, ...

```
friendlycaptcha_skip_dev_validation: '%env(FRIENDLYCAPTCHA_SKIP_DEV_VALIDATION)%'
```

... but even if someone sets it to `1` in the site config, it only can be used in Development context.

Maybe this is helpful for others, too.

![skip-validation](https://github.com/studiomitte/friendlycaptcha-typo3/assets/16088567/da9f106f-7726-4ed9-bb3b-9d189a186f41)
