### PR TITLE
fix double check on optin link

### DIFF
--- a/Classes/FieldValidator/PowermailValidator.php
+++ b/Classes/FieldValidator/PowermailValidator.php
@@ -62,7 +62,8 @@ class PowermailValidator extends AbstractValidator
     {
         if (property_exists($this, 'flexForm')) {
             $confirmationActive = $this->flexForm['settings']['flexform']['main']['confirmation'] === '1';
-            return $this->getActionName() === 'create' && $confirmationActive;
+            $optinActive = $this->flexForm['settings']['flexform']['main']['optin'] === '1';
+            return ($this->getActionName() === 'create' && $confirmationActive) || ($this->getActionName() === 'optinConfirm' && $optinActive);
         }
         return false;
     }


### PR DESCRIPTION
The double opt in link does currently result in a error because of double check the captcha in optinConfirm Action. This patch should solve that problem. Please be so kind and have a look. 