### PR TITLE
[BUGFIX] Add missing quote to TypoScript import

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -22,7 +22,7 @@ module.tx_form.settings.yamlConfigurations {
 }
 
 if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('powermail')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('@import "EXT:friendlycaptcha_official/Configuration/TypoScript/Powermail/setup.typoscript');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('@import "EXT:friendlycaptcha_official/Configuration/TypoScript/Powermail/setup.typoscript"');
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('@import "EXT:friendlycaptcha_official/Configuration/PageTsConfig/powermail.typoscript"');
 }
 


### PR DESCRIPTION
For every request, TYPO3 warns about the Illegal filepath caused by the missing quote in the `@import` TypoScript statement.
```
Sun, 02 Jun 2024 00:00:00 +0200 [WARNING] request="XXX" component="TYPO3.CMS.Core.TypoScript.Parser.TypoScriptParser": Illegal filepath "EXT:friendlycaptcha_official/Configuration/TypoScript/Powermail/setup.typoscript
```