### PR TITLE
[TASK] Update readme for new compatibility and remove leftover deprecated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # TYPO3 Extension `friendlycaptcha_official`
 
-[![Total Downloads](http://poser.pugx.org/studiomitte/friendlycaptcha/downloads)](https://packagist.org/packages/studiomitte/friendlycaptcha)
-[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
+[![Total Downloads](https://poser.pugx.org/studiomitte/friendlycaptcha/downloads)](https://packagist.org/packages/studiomitte/friendlycaptcha)
 [![TYPO3 12](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://get.typo3.org/version/12)
-[![License](http://poser.pugx.org/studiomitte/friendlycaptcha/license)](https://packagist.org/packages/studiomitte/friendlycaptcha)
+[![TYPO3 13](https://img.shields.io/badge/TYPO3-13-orange.svg)](https://get.typo3.org/version/13)
+[![License](https://poser.pugx.org/studiomitte/friendlycaptcha/license)](https://packagist.org/packages/studiomitte/friendlycaptcha)
 
-[![Build 11](https://github.com/studiomitte/friendlycaptcha-typo3/actions/workflows/core11.yml/badge.svg)](https://github.com/studiomitte/friendlycaptcha-typo3/actions/workflows/core11.yml)
 [![Build 12](https://github.com/studiomitte/friendlycaptcha-typo3/actions/workflows/core12.yml/badge.svg)](https://github.com/studiomitte/friendlycaptcha-typo3/actions/workflows/core12.yml)
+[![Build 13](https://github.com/studiomitte/friendlycaptcha-typo3/actions/workflows/core13.yml/badge.svg)](https://github.com/studiomitte/friendlycaptcha-typo3/actions/workflows/core13.yml)
 
 This extension integrations the GDPR-compliant captcha service of [**Friendly Captcha**](https://friendlycaptcha.com/) into TYPO3.
 
 Supported TYPO3 versions:
 
-- 11.5 LTS
 - 12.4 LTS
+- 13.4 LTS
 
 Supported form extensions:
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,13 +1,5 @@
 <?php
 
-/** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
-$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-$iconRegistry->registerIcon(
-    'Friendlycaptcha-icon',
-    \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-    ['source' => 'EXT:friendlycaptcha_official/Resources/Public/Icons/Captcha-icon.svg']
-);
-
 if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('
 # Settings for Frontend


### PR DESCRIPTION
While checking out this extension I noticed that the README is outdated and that there is leftover code that is no longer required. Or never was required – as far as I can see version 0.0.1 was compatible with TYPO3 11 and already had the `Configuration/Icons.php` file which has been supported since TYPO3 11.