### PR TITLE
[TASK] Fix nullable type declaration for $site in Configuration

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -20,7 +20,7 @@ class Configuration
     protected string $jsPath = '';
     protected bool $skipDevValidation = false;
 
-    public function __construct(Site $site = null)
+    public function __construct(?Site $site = null)
     {
         if ($site === null) {
             $site = $GLOBALS['TYPO3_REQUEST']->getAttribute('site');


### PR DESCRIPTION
The constructor parameter `$site` in `StudioMitte\FriendlyCaptcha\Configuration` was implicitly nullable, which triggers a deprecation warning in PHP 8.4. This change explicitly declares the parameter as nullable (`?string`) to ensure compatibility with PHP 8.4+.